### PR TITLE
Make TestResult.timestamp timezone-aware using UTC

### DIFF
--- a/src/promptum/session/result.py
+++ b/src/promptum/session/result.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from promptum.providers.metrics import Metrics
@@ -14,4 +14,4 @@ class TestResult:
     metrics: Metrics | None
     validation_details: dict[str, Any]
     execution_error: str | None = None
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=lambda:datetime.now(timezone.utc))


### PR DESCRIPTION
Hey there, just wanted to say that this change makes `TestResult.timestamp` timezone-aware by using `datetime.now(timezone.utc)` instead of a naive `datetime.now()`.

##changes
- Import `timezone` from `datetime`
- Replace `default_factory=datetime.now` with:
  `default_factory=lambda: datetime.now(timezone.utc)`



##TESTS
All existing tests pass with this change.

Resolve #16 
