### PR TITLE
#18: Prevent overriding reserved payload fields in OpenRouterClient.g…

### DIFF
--- a/src/promptum/providers/openrouter.py
+++ b/src/promptum/providers/openrouter.py
@@ -63,7 +63,14 @@ class OpenRouterClient:
         }
         if max_tokens is not None:
             payload["max_tokens"] = max_tokens
+        reserved_keys: set[str] = {"model", "messages", "temperature", "max_tokens"}
+        conflicts = reserved_keys.intersection(kwargs.keys())
+        if conflicts:
+            raise ValueError(
+                f"Cannot override reserved payload fields: {', '.join(sorted(conflicts))}"
+                )
         payload.update(kwargs)
+
 
         for attempt in range(config.max_attempts):
             start_time = time.perf_counter()

--- a/tests/providers/test_openrouter.py
+++ b/tests/providers/test_openrouter.py
@@ -1,0 +1,16 @@
+import pytest
+
+from promptum.providers.openrouter import OpenRouterClient
+
+
+@pytest.mark.asyncio
+async def test_generate_rejects_reserved_field_override():
+    async with OpenRouterClient(api_key="test-key") as client:
+        with pytest.raises(ValueError) as exc_info:
+            await client.generate(
+                prompt="hello",
+                model="test-model",
+                messages=[{"role": "user", "content": "injected"}],
+            )
+
+    assert "messages" in str(exc_info.value)


### PR DESCRIPTION
**Summary**

Prevents overriding reserved payload fields (model, messages, temperature, max_tokens) in OpenRouterClient.generate.

Previously, payload.update(kwargs) allowed these fields to be silently overridden, which could break the API contract and lead to subtle bugs.

**Changes**

Added validation for reserved field overrides

Raise ValueError when conflicts are detected

Added regression test to enforce behaviour

**Rationale**

This aligns with Promptum’s goal of predictable, type-safe behaviour by protecting internal payload invariants.

Resolve #18 