### PR TITLE
#19 Protect Report.results immutability by converting to tuple in  __post_init__

### DIFF
--- a/src/promptum/session/report.py
+++ b/src/promptum/session/report.py
@@ -7,7 +7,7 @@ from promptum.session.summary import Summary
 
 @dataclass(frozen=True, slots=True)
 class Report:
-    results: tuple[TestResult, ...]
+    results: Sequence[TestResult]
 
     def __post_init__(self):
         object.__setattr__(self, "results", tuple(self.results))


### PR DESCRIPTION
Ensure Report.results is immutable by converting the sequence to a tuple in __post_init__.

Resolve #19 