### PR TITLE
#53: Add test for Regex.validate() with non-zero flags

### DIFF
--- a/tests/validation/test_regex.py
+++ b/tests/validation/test_regex.py
@@ -1,3 +1,5 @@
+import re
+
 from promptum.validation import Regex
 
 
@@ -29,3 +31,11 @@ def test_regex_describe() -> None:
     description = validator.describe()
     assert "Regex" in description
     assert r"\d+" in description
+
+def test_regex_with_ignorecase_flag() -> None:
+    validator = Regex(r"hello", flags=re.IGNORECASE)
+
+    passed, details = validator.validate("HELLO")
+
+    assert passed is True
+    assert details["matched"] == "HELLO"


### PR DESCRIPTION
Adds a test verifying that Regex.validate() correctly forwards non-zero flags to the underlying regex engine.

This covers the previously untested flag-forwarding path.