### PR TITLE
#51: Add test for JsonSchema.describe() with empty required_keys

### DIFF
--- a/tests/validation/test_json_schema.py
+++ b/tests/validation/test_json_schema.py
@@ -41,3 +41,9 @@ def test_json_schema_describe() -> None:
     assert "Valid JSON" in description
     assert "a" in description
     assert "b" in description
+
+def test_json_schema_describe_without_required_keys() -> None:
+    validator = JsonSchema(required_keys=())
+    description = validator.describe()
+
+    assert description == "Valid JSON object"


### PR DESCRIPTION
Adds a test covering the empty required_keys branch in JsonSchema.describe().