### PR TITLE
test: add tests for non-dict JSON validation in JsonSchema

### DIFF
--- a/tests/validation/test_json_schema.py
+++ b/tests/validation/test_json_schema.py
@@ -1,3 +1,4 @@
+from promptum.validation.validators import JsonSchema
 from promptum.validation import JsonSchema
 
 
@@ -48,3 +49,39 @@ def test_json_schema_describe_without_required_keys() -> None:
     description = validator.describe()
 
     assert description == "Valid JSON object"
+
+
+
+
+class TestJsonSchema:
+    def test_valid_dict(self):
+        validator = JsonSchema()
+        passed, details = validator.validate('{"name": "Shreyas"}')
+        assert passed is True
+
+    def test_array_returns_false(self):
+        validator = JsonSchema()
+        passed, details = validator.validate("[1, 2, 3]")
+        assert passed is False
+        assert "error" in details
+        
+
+    def test_number_returns_false(self):
+        validator = JsonSchema()
+        passed, details = validator.validate("42")
+        assert passed is False
+        assert "error" in details
+   
+      
+
+    def test_invalid_json_returns_false(self):
+        validator = JsonSchema()
+        passed, details = validator.validate("Shreyas")
+        assert passed is False
+        assert "error" in details
+   
+    def test_missing_required_keys(self):
+        validator = JsonSchema(required_keys=("name", "age"))
+        passed, details = validator.validate('{"name": "Shreyas"}')
+        assert passed is False
+        assert "age" in details["missing_keys"]

--- a/tests/validation/test_json_schema.py
+++ b/tests/validation/test_json_schema.py
@@ -1,5 +1,4 @@
 from promptum.validation.validators import JsonSchema
-from promptum.validation import JsonSchema
 
 
 def test_json_schema_valid(json_schema_validator: JsonSchema) -> None:
@@ -51,8 +50,6 @@ def test_json_schema_describe_without_required_keys() -> None:
     assert description == "Valid JSON object"
 
 
-
-
 class TestJsonSchema:
     def test_valid_dict(self):
         validator = JsonSchema()
@@ -64,22 +61,19 @@ class TestJsonSchema:
         passed, details = validator.validate("[1, 2, 3]")
         assert passed is False
         assert "error" in details
-        
 
     def test_number_returns_false(self):
         validator = JsonSchema()
         passed, details = validator.validate("42")
         assert passed is False
         assert "error" in details
-   
-      
 
     def test_invalid_json_returns_false(self):
         validator = JsonSchema()
         passed, details = validator.validate("Shreyas")
         assert passed is False
         assert "error" in details
-   
+
     def test_missing_required_keys(self):
         validator = JsonSchema(required_keys=("name", "age"))
         passed, details = validator.validate('{"name": "Shreyas"}')


### PR DESCRIPTION
Closes #54 

Added tests covering the untested branch in JsonSchema.validate() 
where valid JSON is not a dict:

- test_array_returns_false: "[1, 2, 3]" returns False with error
- test_number_returns_false: "42" returns False with error
- test_invalid_json_returns_false: invalid JSON returns False with error
- test_valid_dict: valid JSON dict passes correctly
- test_missing_required_keys: missing keys returns False

All 84 tests pass with coverage requirements met.